### PR TITLE
Ensemble example rotates colors across multiple Sphero minis

### DIFF
--- a/lib/examples/ensemble.d.ts
+++ b/lib/examples/ensemble.d.ts
@@ -1,2 +1,3 @@
 import { SpheroMini } from '../toys/sphero-mini';
+export declare const setEachMiniColor: (minis: SpheroMini[], r: number, g: number, b: number) => Promise<void>;
 export declare const ensemble: (minis: SpheroMini[]) => Promise<void>;

--- a/lib/examples/ensemble.d.ts
+++ b/lib/examples/ensemble.d.ts
@@ -1,0 +1,2 @@
+import { SpheroMini } from '../toys/sphero-mini';
+export declare const ensemble: (minis: SpheroMini[]) => Promise<void>;

--- a/lib/examples/ensemble.js
+++ b/lib/examples/ensemble.js
@@ -1,0 +1,60 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const sphero_mini_1 = require("../toys/sphero-mini");
+const utils_1 = require("../utils");
+const scanner_1 = require("./lib/scanner");
+// import * as noble from 'noble';
+const WAIT_TIME = 100;
+exports.ensemble = async (minis) => {
+    // Cycle 10 times. On each cycle set each bot to white, green, then red.
+    for (let i = 0; i < 10; i++) {
+        // set each mini's color to white
+        for (const mini of minis) {
+            await mini.setMainLedColor(0xFF, 0xFF, 0xFF);
+            await utils_1.wait(WAIT_TIME);
+        }
+        // set each mini's color to green
+        for (const mini of minis) {
+            await mini.setMainLedColor(0, 0xFF, 0);
+            await utils_1.wait(WAIT_TIME);
+        }
+        // set each mini's color to red
+        for (const mini of minis) {
+            await mini.setMainLedColor(0xFF, 0, 0);
+            await utils_1.wait(WAIT_TIME);
+        }
+    }
+    // Put each mini to sleep
+    for (const mini of minis) {
+        await mini.sleep();
+    }
+    process.exit();
+};
+const main = async () => {
+    // Find all bots that advertise as a Sphero Mini
+    const bots = await scanner_1.findToys([sphero_mini_1.SpheroMini.advertisement]);
+    // sort the minis by their bluetooth advertisment local name (e.g, "SM-????")
+    bots.sort((a, b) => {
+        if (a.peripheral.advertisement.localName < b.peripheral.advertisement.localName) {
+            return -1;
+        }
+        else if (a.peripheral.advertisement.localName > b.peripheral.advertisement.localName) {
+            return 1;
+        }
+        return 0;
+    });
+    // start each bot, cast it to a SpheroMini object, then add to an array
+    const minis = [];
+    for (const bot of bots) {
+        // cast bot to a Core object
+        const toy = new sphero_mini_1.SpheroMini.advertisement.class(bot.peripheral);
+        await toy.start();
+        await toy.wake();
+        // cast Core toy to a SpheroMini
+        const mini = toy;
+        minis.push(mini);
+    }
+    // run the ensemble action on the array of minis
+    exports.ensemble(minis);
+};
+main();

--- a/lib/examples/ensemble.js
+++ b/lib/examples/ensemble.js
@@ -5,24 +5,21 @@ const utils_1 = require("../utils");
 const scanner_1 = require("./lib/scanner");
 // import * as noble from 'noble';
 const WAIT_TIME = 100;
+exports.setEachMiniColor = async (minis, r, g, b) => {
+    for (const mini of minis) {
+        await mini.setMainLedColor(r, g, b);
+        await utils_1.wait(WAIT_TIME);
+    }
+};
 exports.ensemble = async (minis) => {
     // Cycle 10 times. On each cycle set each bot to white, green, then red.
     for (let i = 0; i < 10; i++) {
         // set each mini's color to white
-        for (const mini of minis) {
-            await mini.setMainLedColor(0xFF, 0xFF, 0xFF);
-            await utils_1.wait(WAIT_TIME);
-        }
+        await exports.setEachMiniColor(minis, 0xFF, 0xFF, 0xFF);
         // set each mini's color to green
-        for (const mini of minis) {
-            await mini.setMainLedColor(0, 0xFF, 0);
-            await utils_1.wait(WAIT_TIME);
-        }
+        await exports.setEachMiniColor(minis, 0, 0xFF, 0);
         // set each mini's color to red
-        for (const mini of minis) {
-            await mini.setMainLedColor(0xFF, 0, 0);
-            await utils_1.wait(WAIT_TIME);
-        }
+        await exports.setEachMiniColor(minis, 0xFF, 0, 0);
     }
     // Put each mini to sleep
     for (const mini of minis) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cmd": "ts-node src/examples/cmd",
     "collision": "ts-node src/examples/collisionDetection",
     "police": "ts-node src/examples/police",
+    "ensemble": "ts-node src/examples/ensemble",
     "sensor": "ts-node src/examples/sensor"
   },
   "pre-commit": [

--- a/src/examples/ensemble.ts
+++ b/src/examples/ensemble.ts
@@ -7,24 +7,24 @@ import { Core } from '../toys/core';
 
 const WAIT_TIME: number = 100;
 
+export const setEachMiniColor = async (minis: SpheroMini[], r: number, g: number, b: number) => {
+  for (const mini of minis) {
+    await mini.setMainLedColor(r, g, b);
+    await wait(WAIT_TIME);
+  }
+};
+
 export const ensemble = async (minis: SpheroMini[]) => {
   // Cycle 10 times. On each cycle set each bot to white, green, then red.
   for (let i = 0; i < 10; i++) {
     // set each mini's color to white
-    for (const mini of minis) {
-      await mini.setMainLedColor(0xFF, 0xFF, 0xFF);
-      await wait(WAIT_TIME);
-    }
+    await setEachMiniColor(minis, 0xFF, 0xFF, 0xFF);
+
     // set each mini's color to green
-    for (const mini of minis) {
-      await mini.setMainLedColor(0, 0xFF, 0);
-      await wait(WAIT_TIME);
-    }
+    await setEachMiniColor(minis, 0, 0xFF, 0);
+
     // set each mini's color to red
-    for (const mini of minis) {
-      await mini.setMainLedColor(0xFF, 0, 0);
-      await wait(WAIT_TIME);
-    }
+    await setEachMiniColor(minis, 0xFF, 0, 0);
   }
 
   // Put each mini to sleep

--- a/src/examples/ensemble.ts
+++ b/src/examples/ensemble.ts
@@ -1,40 +1,34 @@
 import { SpheroMini } from '../toys/sphero-mini';
 import { wait } from '../utils';
-import { findSpheroMini } from './lib/scanner';
 import { findToys } from './lib/scanner';
 
-import { Core } from '../../toys/core';
-import { Peripheral } from 'noble';
-import * as noble from 'noble';
-
-import { IToyAdvertisement } from '../../toys/types';
+import { Core } from '../toys/core';
+// import * as noble from 'noble';
 
 const WAIT_TIME: number = 100;
 
 export const ensemble = async (minis: SpheroMini[]) => {
-  var i=0;
   // Cycle 10 times. On each cycle set each bot to white, green, then red.
-  while (i < 10) {
+  for (let i = 0; i < 10; i++) {
     // set each mini's color to white
-    for (let mini of minis) {
+    for (const mini of minis) {
       await mini.setMainLedColor(0xFF, 0xFF, 0xFF);
       await wait(WAIT_TIME);
     }
     // set each mini's color to green
-    for (let mini of minis) {
+    for (const mini of minis) {
       await mini.setMainLedColor(0, 0xFF, 0);
       await wait(WAIT_TIME);
     }
     // set each mini's color to red
-    for (let mini of minis) {
+    for (const mini of minis) {
       await mini.setMainLedColor(0xFF, 0, 0);
       await wait(WAIT_TIME);
     }
-    i++;
   }
 
   // Put each mini to sleep
-  for (let mini of minis) {
+  for (const mini of minis) {
     await mini.sleep();
   }
   process.exit();
@@ -46,17 +40,17 @@ const main = async () => {
 
   // sort the minis by their bluetooth advertisment local name (e.g, "SM-????")
   bots.sort((a, b): number => {
-    if (a.peripheral.advertisement.localName < b.peripheral.advertisement.localName)
+    if (a.peripheral.advertisement.localName < b.peripheral.advertisement.localName) {
       return -1;
-    if (a.peripheral.advertisement.localName > b.peripheral.advertisement.localName)
+    } else if (a.peripheral.advertisement.localName > b.peripheral.advertisement.localName) {
       return 1;
+    }
     return 0;
   });
 
   // start each bot, cast it to a SpheroMini object, then add to an array
-  let minis = [];
-  for(let bot of bots) {
-    console.log("Starting: " + bot.peripheral.advertisement.localName);
+  const minis = [];
+  for (const bot of bots) {
     // cast bot to a Core object
     const toy: Core = new SpheroMini.advertisement.class(bot.peripheral);
     await toy.start();
@@ -69,6 +63,5 @@ const main = async () => {
   // run the ensemble action on the array of minis
   ensemble(minis);
 };
-
 
 main();

--- a/src/examples/ensemble.ts
+++ b/src/examples/ensemble.ts
@@ -1,0 +1,74 @@
+import { SpheroMini } from '../toys/sphero-mini';
+import { wait } from '../utils';
+import { findSpheroMini } from './lib/scanner';
+import { findToys } from './lib/scanner';
+
+import { Core } from '../../toys/core';
+import { Peripheral } from 'noble';
+import * as noble from 'noble';
+
+import { IToyAdvertisement } from '../../toys/types';
+
+const WAIT_TIME: number = 100;
+
+export const ensemble = async (minis: SpheroMini[]) => {
+  var i=0;
+  // Cycle 10 times. On each cycle set each bot to white, green, then red.
+  while (i < 10) {
+    // set each mini's color to white
+    for (let mini of minis) {
+      await mini.setMainLedColor(0xFF, 0xFF, 0xFF);
+      await wait(WAIT_TIME);
+    }
+    // set each mini's color to green
+    for (let mini of minis) {
+      await mini.setMainLedColor(0, 0xFF, 0);
+      await wait(WAIT_TIME);
+    }
+    // set each mini's color to red
+    for (let mini of minis) {
+      await mini.setMainLedColor(0xFF, 0, 0);
+      await wait(WAIT_TIME);
+    }
+    i++;
+  }
+
+  // Put each mini to sleep
+  for (let mini of minis) {
+    await mini.sleep();
+  }
+  process.exit();
+};
+
+const main = async () => {
+  // Find all bots that advertise as a Sphero Mini
+  const bots = await findToys([SpheroMini.advertisement]);
+
+  // sort the minis by their bluetooth advertisment local name (e.g, "SM-????")
+  bots.sort((a, b): number => {
+    if (a.peripheral.advertisement.localName < b.peripheral.advertisement.localName)
+      return -1;
+    if (a.peripheral.advertisement.localName > b.peripheral.advertisement.localName)
+      return 1;
+    return 0;
+  });
+
+  // start each bot, cast it to a SpheroMini object, then add to an array
+  let minis = [];
+  for(let bot of bots) {
+    console.log("Starting: " + bot.peripheral.advertisement.localName);
+    // cast bot to a Core object
+    const toy: Core = new SpheroMini.advertisement.class(bot.peripheral);
+    await toy.start();
+    await toy.wake();
+    // cast Core toy to a SpheroMini
+    const mini: SpheroMini = toy as SpheroMini;
+    minis.push(mini);
+  }
+
+  // run the ensemble action on the array of minis
+  ensemble(minis);
+};
+
+
+main();


### PR DESCRIPTION
I have three Sphere Minis and wondered if I could have one script to control them all. So I tweaked the "police" sample to connect to all discovered minis and cycle colors across them (in order of their advertised name). It's a really neat effect with 3 or more minis. 

It also demonstrates the challenges with discovering one or more specific toy. As I mentioned in #14, it would be great if I could find all available toys, or a collection of toys that match a given array of advertised names,  and have them returned to me as `SpheroMini` objects. As it is, I must call `findToys()` and then convert the results to `Core` and then to `SpheroMini`. 