### PR TITLE
fixes directory to change into after cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ First run this:
 
 ```sh
 git clone git@github.com:igbopie/spherov2.js.git
-cd sphero2.js
+cd spherov2.js
 yarn install
 ```
 


### PR DESCRIPTION
This is just a small fix for the readme.md file.
The directory created by git clone is called `spherov2.js` instead of `cd sphero2.js`.